### PR TITLE
Fall back to looking for config in main bundle if not found in class bundle

### DIFF
--- a/MobileDeepLinking-iOS/MDLConfig.m
+++ b/MobileDeepLinking-iOS/MDLConfig.m
@@ -41,6 +41,11 @@
     {
         NSError *error = nil;
         NSString *configFilePath = [[NSBundle bundleForClass:[self class]] pathForResource:MOBILEDEEPLINKING_CONFIG_NAME ofType:@"json"];
+        if (configFilePath == nil)
+        {
+            // Fall back to main bundle if not found in class / framework bundle.
+            configFilePath = [[NSBundle mainBundle] pathForResource:MOBILEDEEPLINKING_CONFIG_NAME ofType:@"json"];
+        }
         NSData *configData = [[NSFileManager defaultManager] contentsAtPath:configFilePath];
         NSDictionary *config = [NSJSONSerialization JSONObjectWithData:configData options:0 error:&error];
         if (config == nil)


### PR DESCRIPTION
When including this library using cocoapods with the use_frameworks! option set, this project gets built as an Framework, instead of being statically linked in. 

When compiled as a framework, the MOBILEDEEPLINKING_CONFIG_NAME file is no longer in the same bundle as the framework, as a result fails to find it. 

This PR falls back to looking for the configuration file in the main bundle in the case it can't be found in the same bundle as the class / framework.
